### PR TITLE
Solo Mining fixes for RPC & GUI

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -34,4 +34,8 @@ CBlockTemplate* CreateNewBlockWithAddress(std::string address);
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
+extern double dHashesPerSec;
+extern int64_t nHPSTimerStart;
+extern bool fGenerate;
+
 #endif // BITCOIN_MINER_H

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -172,7 +172,7 @@ public Q_SLOTS:
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
 
     /** set mining status */
-    void setMining(double hashrate, int threads);
+    void setMining(bool mining, double hashrate, int threads, int cores);
 #endif // ENABLE_WALLET
 
 private Q_SLOTS:
@@ -223,6 +223,9 @@ private Q_SLOTS:
 
     /** Show progress dialog e.g. for verifychain */
     void showProgress(const QString &title, int nProgress);
+    
+    /** Update info about mining */
+    void updateMiningIcon();
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -219,6 +219,24 @@ Value setgenerate(const Array& params, bool fHelp)
 
     return Value::null;
 }
+
+Value gethashespersec(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "gethashespersec\n"
+            "\nReturns a recent hashes per second performance measurement while generating.\n"
+            "See the getgenerate and setgenerate calls to turn generation on and off.\n"
+            "\nResult:\n"
+            "n            (numeric) The recent hashes per second when generation is on (will return 0 if generation is off)\n"
+            "\nExamples:\n"
+            + HelpExampleCli("gethashespersec", "")
+            + HelpExampleRpc("gethashespersec", "")
+        );
+    int64_t miners = GetArg("-minermemory", 1);
+    dHashesPerSec = dHashesPerSec * miners;
+    return (int64_t)dHashesPerSec;
+}
 #endif
 
 
@@ -237,6 +255,7 @@ Value getmininginfo(const Array& params, bool fHelp)
             "  \"errors\": \"...\"          (string) Current errors\n"
             "  \"generate\": true|false     (boolean) If the generation is on or off (see getgenerate or setgenerate calls)\n"
             "  \"genproclimit\": n          (numeric) The processor limit for generation. -1 if no generation. (see getgenerate or setgenerate calls)\n"
+            "  \"hashespersec\": n          (numeric) The hashes per second of the generation, or 0 if no generation.\n"
             "  \"pooledtx\": n              (numeric) The size of the mem pool\n"
             "  \"testnet\": true|false      (boolean) If using testnet or not\n"
             "  \"chain\": \"xxxx\",         (string) current network name as defined in BIP70 (main, test, regtest)\n"
@@ -262,6 +281,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("chain",            Params().NetworkIDString()));
 #ifdef ENABLE_WALLET
     obj.push_back(Pair("generate",         getgenerate(params, false)));
+    obj.push_back(Pair("hashespersec",     gethashespersec(params, false)));
 #endif
     return obj;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -308,6 +308,7 @@ static const CRPCCommand vRPCCommands[] =
 #ifdef ENABLE_WALLET
     /* Coin generation */
     { "generating",         "getgenerate",            &getgenerate,            true  },
+    { "generating",         "gethashespersec",        &gethashespersec,        true  },
     { "generating",         "setgenerate",            &setgenerate,            true  },
     { "generating",         "generate",               &generate,               true  },
 #endif

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -163,6 +163,7 @@ extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHe
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value generate(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnetworkhashps(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gethashespersec(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmininginfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value prioritisetransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblocktemplate(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Add support back for returning current HPS speed via RPC console. Users no longer have to watch the debug.log output to see their HPS.

Also included is the Qt mining icon fixes to dynamically update mining statistics for the tooltip, as well as support for changing the icon's state when using the RPC console or startup flags to enable mining. Fix for #14