### PR TITLE
Updates for OSX Build, Travis, and gethashespersec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
+    - SDK_URL=http://www.fuzzbawls.pw/sdks
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
 cache:

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,7 +111,7 @@ $(APP_DIST_DIR)/Applications:
 $(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/HOdlcoin-Qt
 
 $(OSX_DMG): $(APP_DIST_EXTRAS)
-	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "Bitcoin-Qt" -no-pad -r -apple -o $@ dist
+	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "HOdlcoin-Qt" -no-pad -r -apple -o $@ dist
 
 $(APP_DIST_DIR)/.background/$(OSX_BACKGROUND_IMAGE): contrib/macdeploy/$(OSX_BACKGROUND_IMAGE)
 	$(MKDIR_P) $(@D)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -234,8 +234,9 @@ Value gethashespersec(const Array& params, bool fHelp)
             + HelpExampleRpc("gethashespersec", "")
         );
     int64_t miners = GetArg("-minermemory", 1);
-    dHashesPerSec = dHashesPerSec * miners;
-    return (int64_t)dHashesPerSec;
+    double dTotalHPS;
+    dTotalHPS = dHashesPerSec * miners;
+    return (int64_t)dTotalHPS;
 }
 #endif
 


### PR DESCRIPTION
[![Build Status](https://travis-ci.org/Fuzzbawls/HOdlcoin.svg?branch=master)](https://travis-ci.org/Fuzzbawls/HOdlcoin)

fixed some typos in the build system for OSX as well as correct the invalid multiplication issue with the gethashespersec RPC call.

*ARM builds known to not work right now, will be reviewed at a later time.

Fixes #39 