### PR TITLE
[Qt] Remove APR column from HOdlings Table

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -578,14 +578,6 @@
      </column>
      <column>
       <property name="text">
-       <string>APR</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
        <string>Accrued Value</string>
       </property>
       <property name="textAlignment">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -209,12 +209,12 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         }
         ui->hodlTable->setItem(i, 1, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, termDeposit.nValue)));
         ui->hodlTable->setItem(i, 2, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest-termDeposit.nValue)));
-        ui->hodlTable->setItem(i, 3, new QTableWidgetItem(QString::number(interestRate)+QString("%")));
-        ui->hodlTable->setItem(i, 4, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest)));
-        ui->hodlTable->setItem(i, 5, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, matureValue)));
-        ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number((term)/561)));
-        ui->hodlTable->setItem(i, 8, new QTableWidgetItem(QString::number(releaseBlock)));
-        ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(lockHeight)));
+        //ui->hodlTable->setItem(i, 3, new QTableWidgetItem(QString::number(interestRate)+QString("%")));
+        ui->hodlTable->setItem(i, 3, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest)));
+        ui->hodlTable->setItem(i, 4, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, matureValue)));
+        ui->hodlTable->setItem(i, 5, new QTableWidgetItem(QString::number((term)/561)));
+        ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight)));
+        ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock)));
         //time_t releaseDate = time(0)+blocksRemaining*154;
 
         time_t rawtime;
@@ -226,7 +226,7 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         strftime(buffer,80,"%d/%m/%Y",timeinfo);
         std::string str(buffer);
 
-        ui->hodlTable->setItem(i, 9, new QTableWidgetItem(QString(buffer)));
+        ui->hodlTable->setItem(i, 8, new QTableWidgetItem(QString(buffer)));
 
         //ui->hodlTable->setItem(i, 9, new QTableWidgetItem(QString::number(interestRatePerBlock)+QString("%")));
 


### PR DESCRIPTION
APR calculated values were confusing for many people.

Remove the entire column for now.