### PR TITLE
[Core] User supplied miningaddress fixes

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -34,6 +34,9 @@ CBlockTemplate* CreateNewBlockWithAddress(std::string address);
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
+/** Check the validity of user provided address */
+bool validateAddress(std::string address);
+
 extern double dHashesPerSec;
 extern int64_t nHPSTimerStart;
 extern bool fGenerate;


### PR DESCRIPTION
In-Wallet miner will now validate the user supplied mining address

Status of the validation is shown in debug.log by displaying either
the supplied address (if valid), or a warning stating that the supplied
address is invalid, which results in the miner thread reverting to
the default behavior of using an address from the local keypool.

Fixes #47