### PR TITLE
Teach getblocktemplate about the post-fork requirements.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1978,7 +1978,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             return state.DoS(100,error("ConnectBlock(): coinbase transaction does not have 1 output"),REJECT_INVALID, "bad-cb-outputtx-number");
         }
         if (block.vtx[0].vout[0].scriptPubKey.GetTermDepositReleaseBlock() != pindex->nHeight+MINERHODLINGPERIOD){
-            return state.DoS(100,error("ConnectBlock(): coinbase transaction does not HOdl for one year, hodlblocks=%d",block.vtx[0].vout[0].scriptPubKey.GetTermDepositReleaseBlock()),REJECT_INVALID, "bad-cb-outputtx-hodlingperiod");
+            return state.DoS(100,error("ConnectBlock(): coinbase transaction does not HOdl for one year, hodlblocks=%d, expected=%d\n",block.vtx[0].vout[0].scriptPubKey.GetTermDepositReleaseBlock(),pindex->nHeight+MINERHODLINGPERIOD),REJECT_INVALID, "bad-cb-outputtx-hodlingperiod");
         }
     }
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -528,8 +528,28 @@ Value getblocktemplate(const Array& params, bool fHelp)
             delete pblocktemplate;
             pblocktemplate = NULL;
         }
-        CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = CreateNewBlock(scriptDummy);
+
+		if (chainActive.Height()+1 >= MINERHODLINGHEIGHT) {
+			LogPrintf("Creating Block post-fork...\n");
+			string ma=GetArg("-miningaddress", "");
+			CReserveKey reservekey(pwalletMain);
+
+			if (ma != "") {
+				if (validateAddress(ma)) {
+					pblocktemplate = CreateNewBlockWithAddress(ma);
+					LogPrintf("Created Block with miningaddress\n");
+				} else {
+					pblocktemplate = CreateNewBlockWithKey(reservekey);
+					LogPrintf("miningaddress invalid, created block with reservekey instead\n");
+				}
+			} else {
+				pblocktemplate = CreateNewBlockWithKey(reservekey);
+				LogPrintf("Created Block with reservekey\n");
+			}
+		} else {
+			CScript scriptDummy = CScript() << OP_TRUE;
+			pblocktemplate = CreateNewBlock(scriptDummy);
+		}
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 


### PR DESCRIPTION
getblocktemplate RPC now uses the same conditionals that the in-wallet
miner uses for block creation.

If a runtime/conf variable 'miningaddress' has been supplied, that
is checked and used if the address is valid. Otherwise a random
keypool address is used instead.

Fixes #67