### PR TITLE
Add autocomplete to hodlcoin-qt's console window.

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -28,6 +28,7 @@
 #include <QScrollBar>
 #include <QThread>
 #include <QTime>
+#include <QStringList>
 
 #if QT_VERSION < 0x050000
 #include <QUrl>
@@ -321,6 +322,17 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->startupTime->setText(model->formatClientStartupTime());
 
         ui->networkName->setText(QString::fromStdString(Params().NetworkIDString()));
+
+		//Setup autocomplete and attach it
+        QStringList wordList;
+        std::vector<std::string> commandList = tableRPC.listCommands();
+        for (size_t i = 0; i < commandList.size(); ++i)
+        {
+            wordList << commandList[i].c_str();
+        }
+
+        autoCompleter = new QCompleter(wordList, this);
+        ui->lineEdit->setCompleter(autoCompleter);
     }
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -267,6 +267,14 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
                 return true;
             }
             break;
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            // forward these events to lineEdit
+            if(obj == autoCompleter->popup()) {
+                QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+                return true;
+            }
+            break;
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
             // Exclude most combinations and keys that emit no text, except paste shortcuts
@@ -333,9 +341,7 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
-
-        // clear the lineEdit after activating from QCompleter
-        connect(autoCompleter, SIGNAL(activated(const QString&)), ui->lineEdit, SLOT(clear()), Qt::QueuedConnection);
+        autoCompleter->popup()->installEventFilter(this);
     }
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -333,6 +333,9 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
+
+        // clear the lineEdit after activating from QCompleter
+        connect(autoCompleter, SIGNAL(activated(const QString&)), ui->lineEdit, SLOT(clear()), Qt::QueuedConnection);
     }
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -11,6 +11,7 @@
 #include "net.h"
 
 #include <QWidget>
+#include <QCompleter>
 
 class ClientModel;
 
@@ -98,6 +99,7 @@ private:
     QStringList history;
     int historyPtr;
     NodeId cachedNodeid;
+    QCompleter *autoCompleter;
 };
 
 #endif // BITCOIN_QT_RPCCONSOLE_H

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -1027,6 +1027,17 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
     g_rpcSignals.PostCommand(*pcmd);
 }
 
+std::vector<std::string> CRPCTable::listCommands() const
+{
+    std::vector<std::string> commandList;
+    typedef std::map<std::string, const CRPCCommand*> commandMap;
+
+    std::transform( mapCommands.begin(), mapCommands.end(),
+                   std::back_inserter(commandList),
+                   boost::bind(&commandMap::value_type::first,_1) );
+    return commandList;
+}
+
 std::string HelpExampleCli(string methodname, string args){
     return "> bitcoin-cli " + methodname + " " + args + "\n";
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -120,6 +120,13 @@ public:
      * @throws an exception (json_spirit::Value) when an error happens.
      */
     json_spirit::Value execute(const std::string &method, const json_spirit::Array &params) const;
+
+    /**
+    * Returns a list of registered commands
+    * @returns List of registered commands.
+    */
+    std::vector<std::string> listCommands() const;
+
 };
 
 extern const CRPCTable tableRPC;


### PR DESCRIPTION
A new feature from upstream adds auto-completion to the GUI's debug console. I've cherry-picked the relevant commits for inclusion into hodlcoin-qt and have done basic testing.

![screen shot 2016-07-27 at 8 07 39 pm](https://cloud.githubusercontent.com/assets/7393257/17199942/e198a10e-5435-11e6-8501-bb16e7cbd49c.png)


Pulled from bitcoin#7613 bitcoin#7772 and bitcoin#8129