### PR TITLE
[Qt] Guard against missing BDB when compiling without wallet support

### DIFF
--- a/src/qt/depositcoinsdialog.h
+++ b/src/qt/depositcoinsdialog.h
@@ -6,7 +6,10 @@
 #define BITCOIN_QT_DEPOSITCOINSDIALOG_H
 
 #include "walletmodel.h"
-#include "wallet/wallet.h"
+
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h" // for COutput
+#endif // ENABLE_WALLET
 
 #include <QDialog>
 #include <QString>
@@ -52,8 +55,10 @@ public Q_SLOTS:
     void accept();
     SendCoinsEntry *addEntry();
     void updateTabsAndLabels();
+#ifdef ENABLE_WALLET
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
+#endif // ENABLE_WALLET
 
 private:
     Ui::DepositCoinsDialog *ui;

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -7,7 +7,10 @@
 
 #include "amount.h"
 #include "primitives/transaction.h"
-#include "wallet/wallet.h"
+
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h" // for COutput
+#endif // ENABLE_WALLET
 
 #include <QWidget>
 
@@ -38,8 +41,10 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 public Q_SLOTS:
+#ifdef ENABLE_WALLET
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
+#endif // ENABLE_WALLET
 
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -6,7 +6,10 @@
 #define BITCOIN_QT_SENDCOINSDIALOG_H
 
 #include "walletmodel.h"
-#include "wallet/wallet.h"
+
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h" // for COutput
+#endif // ENABLE_WALLET
 
 #include <QDialog>
 #include <QString>
@@ -52,8 +55,10 @@ public Q_SLOTS:
     void accept();
     SendCoinsEntry *addEntry();
     void updateTabsAndLabels();
+#ifdef ENABLE_WALLET
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
+#endif // ENABLE_WALLET
 
 private:
     Ui::SendCoinsDialog *ui;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -9,7 +9,10 @@
 #include "walletmodeltransaction.h"
 
 #include "support/allocators/secure.h"
-#include "wallet/wallet.h"
+
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h" // for COutput
+#endif
 
 
 #include <map>
@@ -138,7 +141,9 @@ public:
     CAmount getWatchBalance() const;
     CAmount getWatchUnconfirmedBalance() const;
     CAmount getWatchImmatureBalance() const;
+#ifdef ENABLE_WALLET
     std::vector<COutput> GetTermDepositInfo() const;
+#endif // ENABLE_WALLET
 
     EncryptionStatus getEncryptionStatus() const;
 
@@ -232,9 +237,11 @@ private:
     void checkBalanceChanged();
 
 Q_SIGNALS:
+#ifdef ENABLE_WALLET
     // Signal that balance in wallet changed
     void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                         const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
+#endif // ENABLE_WALLET
 
     // Encryption status of wallet changed
     void encryptionStatusChanged(int status);


### PR DESCRIPTION
The check for BDB's existence is skipped when compiling with the `--disable-wallet` flag
as it is not needed for node-only operation. However, certain header files still reference
it's inclusion.