### PR TITLE
[RPC] Guard getblocktemplate against no-wallet builds

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -376,6 +376,25 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }
 
+bool validateAddress(std::string address)
+{
+    CBitcoinAddress addressParsed(address);
+    return addressParsed.IsValid();
+}
+
+CBlockTemplate* CreateNewBlockWithAddress(std::string address)
+{
+    CScript scriptPubKey;
+    if(chainActive.Height()+1>=MINERHODLINGHEIGHT){
+        scriptPubKey = GetTimeLockScriptForDestination(CBitcoinAddress(address).Get(),chainActive.Height()+1+MINERHODLINGPERIOD);
+    }
+    else{
+        scriptPubKey = GetScriptForDestination(CBitcoinAddress(address).Get());
+    }
+
+    return CreateNewBlock(scriptPubKey);
+}
+
 #ifdef ENABLE_WALLET
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -433,19 +452,6 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey)
     }else{
         scriptPubKey = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
     }
-    return CreateNewBlock(scriptPubKey);
-}
-
-CBlockTemplate* CreateNewBlockWithAddress(std::string address)
-{
-    CScript scriptPubKey;
-    if(chainActive.Height()+1>=MINERHODLINGHEIGHT){
-        scriptPubKey = GetTimeLockScriptForDestination(CBitcoinAddress(address).Get(),chainActive.Height()+1+MINERHODLINGPERIOD);
-    }
-    else{
-        scriptPubKey = GetScriptForDestination(CBitcoinAddress(address).Get());
-    }
-
     return CreateNewBlock(scriptPubKey);
 }
 
@@ -648,12 +654,6 @@ void static BitcoinMiner(CWallet *pwallet, uint32_t minerI, uint32_t minerN, int
         fGenerate = false;
         return;
     }
-}
-
-bool validateAddress(std::string address)
-{
-    CBitcoinAddress addressParsed(address);
-    return addressParsed.IsValid();
 }
 
 static bool isInterrupting=false;


### PR DESCRIPTION
Post-fork block requirements need the coinbase transaction
to be term-locked for 1 year. The below logic restricts the
use of getblocktemplate to the following pathway:

  1. Use the user supplied miningaddress (if present & valid)
  2. Fallback to random keypool address
  3. Throw an error if no wallet loaded and no miningaddress

This guards against using an invalid dummy address and forces
users that run without a wallet to supply a valid miningaddress
at runtime (in the conf file or	on the command line)