### PR TITLE
Faster block loading times

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#**HODLcoin** [![Build Status](https://travis-ci.org/HOdlcoin/HOdlcoin.svg?branch=HODLCoin0.11.3)](https://travis-ci.org/HOdlcoin/HOdlcoin) [![GitHub version](https://badge.fury.io/gh/HOdlcoin%2FHOdlcoin.svg)](https://badge.fury.io/gh/HOdlcoin%2FHOdlcoin)
+# **HODLcoin** [![Build Status](https://travis-ci.org/HOdlcoin/HOdlcoin.svg?branch=HODLCoin0.11.3)](https://travis-ci.org/HOdlcoin/HOdlcoin) [![GitHub version](https://badge.fury.io/gh/HOdlcoin%2FHOdlcoin.svg)](https://badge.fury.io/gh/HOdlcoin%2FHOdlcoin)
 <img src="http://i.imgur.com/5EAaA7b.png" width="400">
 
 [http://www.HOdlcoin.com](http://www.HOdlcoin.com)
-###**What is it?**
+### **What is it?**
 
 **HOdlcoin** is a Cryptocurrency just like Bitcoin, but with one major difference. It pays interest on every balance. This is to recognize the importance of **HODLers** and properly reward them for **HODLing**.
 
-##**Compound Interest on all Balances**
+## **Compound Interest on all Balances**
 
 Interest is paid on all outputs (**Balances**) and compounded on each block. This is to discourage rolling outputs into new blocks simply to compound interest.
 
-####**Benefits:**
+#### **Benefits:**
 > -  Exciting for HOdlers to see their balances continually increase as each block is received.
 > -  Interest discourages users from leaving large balances on exchanges - expensive to maintain large sell walls.
 > -  Interest encourages users to keep their balances, reducing supply
@@ -19,22 +19,22 @@ Interest is paid on all outputs (**Balances**) and compounded on each block. Thi
 > -  Encourages exchanges to trade in the coin, as they can earn interest on customer's deposits
 > -  Unconfirmed transactions become more valuable over time, as their inputs continue to earn interest. 
 
-##**Deposit Interest** 
+## **Deposit Interest** 
 Paid on **Term Deposits** (aka Fixed deposit / time deposit)
 
 This allows users to lock up funds for a specified amount of time up to a year, to earn a bonus rate of interest.  
 
-####**Why?**
+#### **Why?**
 
  - This encourages and reward HOdlers.
  - Term deposits also constrain supply - term deposit coins cannot be moved until term ends.
 
 Interest is handled in the blockchain and protocol using **CHECKLOCKTIMEVERIFY**. There is no counterparty. 
 
-##**Fixed Parameters**
+## **Fixed Parameters**
 > The PoW Algorithm is considered a technical detail and is subject to change to favor CPU and consumer grade hardware with the intention of keeping mining participatory and distributed.
 
-#####**ALL OTHER PARAMETERS ARE SET IN STONE.**
+##### **ALL OTHER PARAMETERS ARE SET IN STONE.**
 
 > **Note:** No changes to mining subsidies, interest rates, distribution etc.
 
@@ -46,7 +46,7 @@ Interest is handled in the blockchain and protocol using **CHECKLOCKTIMEVERIFY**
  - Standard interest payment 5% on **all** outputs for up to 30 days
  - Term deposit for 1 year 10% APR
 
-###**Term deposits**
+### **Term deposits**
 
 Term     | % of Total APR
 -------- | ---
@@ -57,7 +57,7 @@ Term     | % of Total APR
 1 year   | ~ 100% 
 
 
-####**Bonus interest payment for early adopters, decreases over 24 months**
+#### **Bonus interest payment for early adopters, decreases over 24 months**
 
 Time     |  APR
 -------- | ---
@@ -76,7 +76,7 @@ Time     |  APR
 > -  Bonus rates are paid on regular balances as well.
 > - The bonus rate is locked at the time of the transaction, the rate you can achieve reduces over time due to the multiplier, but once you're earning that bonus rate, it doesn't reduce.
 
-###**Proof of Work**
+### **Proof of Work**
 
-####**1GB AES Pattern Search PoW** 
+#### **1GB AES Pattern Search PoW** 
 Pattern Search involves filling up RAM with pseudo-random data, and then conducting a search for the start location of an AES encrypted data pattern in that data. Pattern Search is an evolution of the ProtoShares Momentum PoW, first used in MemoryCoin and later modified for use in CryptoNight(Monero,Bytecoin), Ethash(Ethereum).  CPU/GPU friendly.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,7 +159,8 @@ BITCOIN_CORE_H = \
   wallet/db.h \
   wallet/wallet.h \
   wallet/wallet_ismine.h \
-  wallet/walletdb.h
+  wallet/walletdb.h \
+  aescache.h
 
 JSON_H = \
   json/json_spirit.h \
@@ -186,8 +187,7 @@ libbitcoin_server_a_SOURCES = \
   bloom.cpp \
   chain.cpp \
   checkpoints.cpp \
-  init.cpp \
-  leveldbwrapper.cpp \
+  init.cpp \ 
   main.cpp \
   merkleblock.cpp \
   miner.cpp \
@@ -205,7 +205,6 @@ libbitcoin_server_a_SOURCES = \
   rpcserver.cpp \
   script/sigcache.cpp \
   timedata.cpp \
-  txdb.cpp \
   txmempool.cpp \
   validationinterface.cpp \
   $(JSON_H) \
@@ -261,6 +260,9 @@ libbitcoin_common_a_SOURCES = \
   arith_uint256.cpp \
   base58.cpp \
   chainparams.cpp \
+  txdb.cpp \
+  leveldbwrapper.cpp \
+  aescache.cpp \
   coins.cpp \
   compressor.cpp \
   core_read.cpp \
@@ -359,7 +361,7 @@ hodlcoin_cli_LDADD = \
   $(LIBBITCOIN_CLI) \
   $(LIBBITCOIN_UTIL)
 
-hodlcoin_cli_LDADD += $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS)
+hodlcoin_cli_LDADD += $(LIBLEVELDB) $(LIBMEMENV) $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS)
 #
 
 # hodlcoin-tx binary #
@@ -379,7 +381,7 @@ hodlcoin_tx_LDADD = \
   $(LIBBITCOIN_CRYPTO_X86) \
   $(LIBSECP256K1)
 
-hodlcoin_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
+hodlcoin_tx_LDADD += $(LIBLEVELDB) $(LIBMEMENV) $(BOOST_LIBS) $(CRYPTO_LIBS)
 #
 
 # bitcoinconsensus library #

--- a/src/aescache.cpp
+++ b/src/aescache.cpp
@@ -1,0 +1,16 @@
+#include "aescache.h"
+
+CBlockAesCache *aesCache = NULL;
+
+CBlockAesCache::CBlockAesCache(size_t nCacheSize, bool fMemory, bool fWipe) : CLevelDBWrapper(GetDataDir() / "blocks" / "cache", nCacheSize, fMemory, fWipe) {
+}
+
+bool CBlockAesCache::WriteHash(const uint256 &hash, const uint256 &aesHash)
+{
+    return Write(std::make_pair('y', hash), aesHash);
+}
+
+bool CBlockAesCache::ReadHash(const uint256 &hash, uint256 &aesHash)
+{
+    return Read(std::make_pair('y', hash), aesHash);
+}

--- a/src/aescache.h
+++ b/src/aescache.h
@@ -1,0 +1,19 @@
+#ifndef AESCACHE_H
+#define AESCACHE_H
+
+#include "uint256.h"
+#include "leveldbwrapper.h"
+
+class CBlockAesCache : public CLevelDBWrapper
+{
+  public:
+    CBlockAesCache(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+  private:
+    CBlockAesCache(const CBlockAesCache&);
+    void operator=(const CBlockAesCache&);
+  public:
+    bool WriteHash(const uint256 &hash, const uint256 &aesHash);
+    bool ReadHash(const uint256 &hash, uint256 &aesHash);
+};
+
+#endif // AESCACHE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -180,6 +180,9 @@ void Shutdown()
         if (pcoinsTip != NULL) {
             FlushStateToDisk();
         }
+        if (aesCache)
+            aesCache->Flush();
+
         delete pcoinsTip;
         pcoinsTip = NULL;
         delete pcoinscatcher;
@@ -188,6 +191,8 @@ void Shutdown()
         pcoinsdbview = NULL;
         delete pblocktree;
         pblocktree = NULL;
+        delete aesCache; 
+        aesCache = NULL;
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)
@@ -1147,10 +1152,14 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nTotalCache -= nCoinDBCache;
+    size_t nBlockAesCache = nTotalCache / 2 ;
+    nTotalCache -= nBlockAesCache; // use 50% for the aes cache
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+
     LogPrintf("Cache configuration:\n");
     LogPrintf("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
+    LogPrintf("* Using %.1fMiB for aes cache database\n", nBlockAesCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheUsage * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
@@ -1168,6 +1177,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinsdbview;
                 delete pcoinscatcher;
                 delete pblocktree;
+                delete aesCache;
 
                 // Detect database obfuscation by future versions of the DBWrapper
                 bool chainstateScrambled;
@@ -1177,6 +1187,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, chainstateScrambled, false, fReindex);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
+                aesCache = new CBlockAesCache(nBlockAesCache, false, fReindex);
 
                 if (fReindex) {
                     pblocktree->WriteReindexing(true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1847,7 +1847,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
-    if (block.GetHash() == chainparams.GetConsensus().hashGenesisBlock) {
+    if (block.GetHashNoCache() == chainparams.GetConsensus().hashGenesisBlock) {
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
         return true;

--- a/src/main.h
+++ b/src/main.h
@@ -25,6 +25,7 @@
 #include "tinyformat.h"
 #include "txmempool.h"
 #include "uint256.h"
+#include "aescache.h"
 
 #include <algorithm>
 #include <exception>
@@ -495,5 +496,8 @@ extern CCoinsViewCache *pcoinsTip;
 extern CBlockTreeDB *pblocktree;
 
 extern int minerStopFlag;
+
+extern CBlockAesCache *aesCache;
+
 
 #endif // BITCOIN_MAIN_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -11,8 +11,28 @@
 #include "crypto/common.h"
 #include "arith_uint256.h"
 #include "patternsearch.h"
+#include "aescache.h"
+
+extern CBlockAesCache *aesCache;
 
 uint256 CBlockHeader::GetHash() const
+{
+    uint256 hash;
+
+    if (aesCache) {
+        uint256 orig_hash = SerializeHash(*this);
+        if (!aesCache->ReadHash(orig_hash, hash)) {
+            hash = GetHashNoCache();
+            aesCache->WriteHash(orig_hash, hash);
+        }
+    } else {
+        hash = GetHashNoCache();
+    }
+
+    return hash;
+}
+
+uint256 CBlockHeader::GetHashNoCache() const
 {
     uint256 midHash = GetMidHash();
     uint256 cacheBlockHash=Hash(BEGIN(nVersion), END(nFinalCalculation));

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -71,6 +71,7 @@ public:
     }
 
     uint256 GetHash() const;
+    uint256 GetHashNoCache() const;
     uint256 GetMidHash() const;
     uint256 FindBestPatternHash(int& collisions,char *scratchpad,int nThreads,int* minerStopFlag);
 


### PR DESCRIPTION
Hi FreeTrade,

Created new AES cache to hold block headers for faster startup. The first time you pay the same penalty to load the block index as it builds the header cache and verify's their authenticity , once that is done a subsequent load is much faster. 
My testing shows going from 250s down to 5s. ( at the expense of about 26Mb of disk space for the cache). The code takes over 50% of the UTXO reserved space for this cache.
This needs more testing on multiple platforms, but looks promising so far, its up to you to decide to accept/deny this pull request.
  