### PR TITLE
Rebuild term deposit table and mature coins notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 *.tar.gz
 
 *.exe
-src/bitcoin
-src/bitcoind
-src/bitcoin-cli
-src/bitcoin-tx
-src/test/test_bitcoin
-src/qt/test/test_bitcoin-qt
+src/hodlcoin
+src/hodlcoind
+src/hodlcoin-cli
+src/hodlcoin-tx
+src/test/test_hodlcoin
+src/qt/test/test_hodlcoin-qt
+src/qt/hodlcoin-qt
 
 # autoreconf
 Makefile.in

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -134,6 +134,7 @@ QT_MOC_CPP = \
   qt/moc_transactiondescdialog.cpp \
   qt/moc_transactionfilterproxy.cpp \
   qt/moc_transactiontablemodel.cpp \
+  qt/moc_deposittablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
   qt/moc_walletframe.cpp \
@@ -205,6 +206,7 @@ BITCOIN_QT_H = \
   qt/transactionfilterproxy.h \
   qt/transactionrecord.h \
   qt/transactiontablemodel.h \
+  qt/deposittablemodel.h \
   qt/transactionview.h \
   qt/utilitydialog.h \
   qt/walletframe.h \
@@ -313,6 +315,7 @@ BITCOIN_QT_CPP += \
   qt/transactionfilterproxy.cpp \
   qt/transactionrecord.cpp \
   qt/transactiontablemodel.cpp \
+  qt/deposittablemodel.cpp \
   qt/transactionview.cpp \
   qt/walletframe.cpp \
   qt/walletmodel.cpp \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -977,6 +977,18 @@ void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmoun
     message((amount)<0 ? tr("Sent transaction") : tr("Incoming transaction"),
              msg, CClientUIInterface::MSG_INFORMATION);
 }
+
+void BitcoinGUI::maturedCoinsNotification(int count, int unit, CAmount& amount)
+{
+	LogPrintf("got maturedCoinsNotification for %d/%s\n", count, BitcoinUnits::formatWithUnit(BitcoinUnits::HODL, amount, true).data() );
+
+    // On matured coins, make an info balloon
+    QString msg = tr("Count: %1\n").arg(count) +
+                  tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(unit, amount, true));
+    message(tr("Matured coins"),
+             msg, CClientUIInterface::MSG_INFORMATION);
+}
+
 #endif // ENABLE_WALLET
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -173,6 +173,9 @@ public Q_SLOTS:
 
     /** set mining status */
     void setMining(bool mining, double hashrate, int threads, int cores);
+
+    void maturedCoinsNotification(int count, int init, CAmount& amount);
+
 #endif // ENABLE_WALLET
 
 private Q_SLOTS:

--- a/src/qt/deposittablemodel.cpp
+++ b/src/qt/deposittablemodel.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "deposittablemodel.h"
+
+#include "addresstablemodel.h"
+#include "guiconstants.h"
+#include "guiutil.h"
+#include "optionsmodel.h"
+#include "scicon.h"
+#include "transactiondesc.h"
+#include "transactionrecord.h"
+#include "walletmodel.h"
+
+#include "main.h"
+#include "sync.h"
+#include "uint256.h"
+#include "util.h"
+#include "wallet/wallet.h"
+
+#include <QColor>
+#include <QDateTime>
+#include <QDebug>
+#include <QIcon>
+#include <QList>
+
+// Amount column is right-aligned it contains numbers
+static int column_alignments[] = {
+		Qt::AlignLeft|Qt::AlignVCenter, /* status */
+		Qt::AlignRight|Qt::AlignVCenter, /* Principal */
+		Qt::AlignRight|Qt::AlignVCenter, /* Interest */
+		Qt::AlignRight|Qt::AlignVCenter, /* Value */
+		Qt::AlignRight|Qt::AlignVCenter, /* Maturation */
+		Qt::AlignRight|Qt::AlignVCenter, /* Days */
+		Qt::AlignRight|Qt::AlignVCenter, /* deposit block */
+		Qt::AlignRight|Qt::AlignVCenter, /* maturation */
+		Qt::AlignCenter|Qt::AlignVCenter,  /* Date */
+};
+
+DepositTableModel::DepositTableModel(ClientModel *clientModel, QObject *parent)
+: QAbstractTableModel(parent)
+{
+	this->clientModel = clientModel;
+
+	this->columns << tr("Status") << tr("Principal") << tr("Accrued Interest") << tr("Accrued Value")
+								<< tr("On Maturation") << tr("Term (Days)") << tr("Deposit Block") << tr("Maturation Block")
+								<< tr("Estimated Date");
+
+}
+
+static bool compareByDepth(COutput& a, COutput& b) {
+	return b.nDepth < a.nDepth;
+}
+
+int DepositTableModel::update(int unit, std::vector<COutput>& termDepositInfo)
+{
+
+	this->unit = unit;
+
+	clock_t t1 = clock();
+
+	this->beginResetModel();
+	clock_t t2 = clock();
+
+	qSort(termDepositInfo.begin(), termDepositInfo.end(), compareByDepth);
+	clock_t t3 = clock();
+
+	this->tdiCache.clear();
+	this->tdiCache.reserve(termDepositInfo.size());
+	for (int i=0, ii=termDepositInfo.size(); i<ii; i++) {
+
+		COutput ctermDeposit = termDepositInfo.at(i);
+		CTxOut termDeposit = ctermDeposit.tx->vout[ctermDeposit.i];
+
+		// create new record with empty constructor
+		tdiCache.push_back(CacheRecord());
+
+		tdiCache[i].nValue = termDeposit.nValue;
+		tdiCache[i].curHeight = this->clientModel->getNumBlocks();
+		tdiCache[i].lockHeight = tdiCache[i].curHeight-ctermDeposit.nDepth;
+		tdiCache[i].releaseBlock = termDeposit.scriptPubKey.GetTermDepositReleaseBlock();
+		tdiCache[i].term = tdiCache[i].releaseBlock - tdiCache[i].lockHeight;
+		tdiCache[i].blocksRemaining = tdiCache[i].releaseBlock - tdiCache[i].curHeight;
+		tdiCache[i].withInterest = termDeposit.GetValueWithInterest(tdiCache[i].lockHeight,
+				(tdiCache[i].curHeight<tdiCache[i].releaseBlock?tdiCache[i].curHeight:tdiCache[i].releaseBlock));
+		tdiCache[i].matureValue = termDeposit.GetValueWithInterest(tdiCache[i].lockHeight,tdiCache[i].releaseBlock);
+		//tdiCache[i].blocksSoFar = tdiCache[i].curHeight - tdiCache[i].lockHeight;
+		//termDepositInfoCache[i].interestRatePerBlock = pow(((0.0+termDepositInfoCache[i].matureValue)/termDepositInfoCache[i].nValue),1.0/termDepositInfoCache[i].term);
+		//termDepositInfoCache[i].interestRate = (pow(termDepositInfoCache[i].interestRatePerBlock,365*720)-1)*100;
+
+		time_t rawtime;
+		time(&rawtime);
+		rawtime += tdiCache[i].blocksRemaining * 154;
+		memcpy(&tdiCache[i].timeinfo,localtime(&rawtime),sizeof(struct tm));
+
+	}
+	clock_t t4 = clock();
+
+	this->endResetModel();
+	clock_t t5 = clock();
+
+	LogPrintf("list of deposits updated, count=%d beginReset=%f qSort=%f cache=%f endReset=%f\n",
+			tdiCache.size(),
+			((double)t2 - (double)t1) / CLOCKS_PER_SEC,
+			((double)t3 - (double)t2) / CLOCKS_PER_SEC,
+			((double)t4 - (double)t3) / CLOCKS_PER_SEC,
+			((double)t5 - (double)t4) / CLOCKS_PER_SEC
+	);
+
+	return tdiCache.size();
+}
+
+DepositTableModel::~DepositTableModel()
+{
+}
+
+int DepositTableModel::rowCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return tdiCache.size();
+}
+
+int DepositTableModel::columnCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return columns.length();
+}
+
+QVariant DepositTableModel::data(const QModelIndex &index, int role) const
+{
+	if (!index.isValid())
+		return QVariant();
+
+	if (index.row() >= tdiCache.size() || index.row() < 0)
+		return QVariant();
+
+	int nDisplayUnit = this->unit;
+
+	if (role == Qt::TextAlignmentRole)
+	{
+		return column_alignments[index.column()];
+	}
+	else if (role == Qt::DisplayRole || role == SortRole || role == Qt::ToolTipRole)
+	{
+		CacheRecord cache = tdiCache.at(index.row());
+
+		switch(index.column()) {
+		case Status:
+			if (cache.curHeight >= cache.releaseBlock) {
+				if (role == Qt::DisplayRole || role == SortRole)
+					return tr("Matured");
+				else if (role == Qt::ToolTipRole) {
+					return tr("Warning: this amount is no longer earning interest of any kind");
+				}
+			} else {
+				if (role == Qt::DisplayRole || role == SortRole)
+					return tr("Earned");
+			}
+			break;
+		case Principal:
+			if (role == SortRole)
+				return qint64(cache.nValue);
+			else if (role == Qt::DisplayRole)
+				return BitcoinUnits::format(nDisplayUnit, cache.nValue);
+			break;
+		case AccruedInterest:
+			if (role == SortRole)
+				return qint64(cache.withInterest-cache.nValue);
+			else if (role == Qt::DisplayRole)
+				return BitcoinUnits::format(nDisplayUnit, cache.withInterest-cache.nValue);
+			break;
+		case AccruedValue:
+			if (role == SortRole)
+				return qint64(cache.withInterest);
+			else if (role == Qt::DisplayRole)
+				return BitcoinUnits::format(nDisplayUnit, cache.withInterest);
+			break;
+		case OnMaturation:
+			if (role == SortRole)
+				return qint64(cache.matureValue);
+			else if (role == Qt::DisplayRole)
+				return BitcoinUnits::format(nDisplayUnit, cache.matureValue);
+			break;
+		case TermDays:
+			if (role == SortRole)
+				return (cache.term)/720;
+			else if (role == Qt::DisplayRole)
+				return QString::number((cache.term)/720);
+			break;
+		case DepositBlock:
+			if (role == SortRole)
+				return cache.lockHeight;
+			else if (role == Qt::DisplayRole)
+				return QString::number(cache.lockHeight); // .rightJustified(7,'0');
+			break;
+		case MaturationBlock:
+			if (role == SortRole)
+				return cache.releaseBlock;
+			else if (role == Qt::DisplayRole)
+				return QString::number(cache.releaseBlock); // .rightJustified(7,'0');
+			break;
+		case EstimatedDate:
+
+			char buffer[16];
+			strftime(buffer, 16, "%Y/%m/%d", &cache.timeinfo);
+
+			if (role == SortRole)
+				return qint64(mktime(&cache.timeinfo));
+			else if (role == Qt::DisplayRole)
+				return QString(buffer);
+			else if (role == Qt::ToolTipRole) {
+				if (cache.curHeight >= cache.releaseBlock) {
+					int days = (int)(-cache.blocksRemaining/720);
+					switch (days) {
+					case 0:
+						return tr("Matured today");
+					case 1:
+						return tr("Matured yesterday");
+					default:
+						return tr("Matured %1 days ago").arg(days);
+					}
+				} else {
+					int days = (int)(cache.blocksRemaining/720);
+					switch (days) {
+					case 0:
+						return tr("Matures today");
+					case 1:
+						return tr("Matures tomorrow");
+					default:
+						return tr("%1 days to go").arg(days);
+					}
+				}
+			}
+
+			break;
+		}
+	}
+
+	return QVariant();
+}
+
+QVariant DepositTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	if (orientation == Qt::Horizontal)
+	{
+		if (role == Qt::DisplayRole)
+		{
+			return columns[section];
+		}
+		else if (role == Qt::TextAlignmentRole)
+		{
+			return column_alignments[section];
+		}
+		else if (role == Qt::ToolTipRole)
+		{
+			switch(section)
+			{
+
+			case 0:
+				return tr("Deposit Status");
+			case 1:
+				return tr("Principal");
+			case 2:
+				return tr("Accrued Interest");
+			case 3:
+				return tr("Accrued Value");
+			case 4:
+				return tr("Value On Maturation");
+			case 5:
+				return tr("Term (Days)");
+			case 6:
+				return tr("Deposit Block");
+			case 7:
+				return tr("Maturation Block");
+			case 8:
+				return tr("Estimated Date");
+			}
+		}
+	}
+
+	// return QVariant();
+	return QAbstractTableModel::headerData(section, orientation, role);
+}
+

--- a/src/qt/deposittablemodel.h
+++ b/src/qt/deposittablemodel.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_DEPOSITTABLEMODEL_H
+#define BITCOIN_QT_DEPOSITTABLEMODEL_H
+
+#include "bitcoinunits.h"
+#include "wallet/wallet.h"
+#include "clientmodel.h"
+
+#include <QAbstractTableModel>
+#include <QStringList>
+
+typedef struct {
+	CAmount nValue;
+	int curHeight;
+	int lockHeight;
+	int releaseBlock;
+	int term;
+	int blocksRemaining;
+	CAmount withInterest;
+	CAmount matureValue;
+	//int blocksSoFar;
+	//double interestRatePerBlock;
+	//double interestRate;
+	struct tm timeinfo;
+} CacheRecord;
+
+/** UI model for the deposit table of a wallet.
+ */
+class DepositTableModel : public QAbstractTableModel
+{
+	Q_OBJECT
+
+public:
+
+	explicit DepositTableModel(ClientModel *clientModel, QObject *parent=0);
+	// explicit DepositTableModel(ClientModel *clientModel, std::vector<COutput>& termDepositInfo, QObject *parent=0);
+	~DepositTableModel();
+
+	enum ColumnIndex {
+		Status = 0,
+		Principal = 1,
+		AccruedInterest = 2,
+		AccruedValue = 3,
+		OnMaturation = 4,
+		TermDays = 5,
+		DepositBlock = 6,
+		MaturationBlock = 7,
+		EstimatedDate = 8,
+	};
+
+	/** Roles to get specific information from a row.
+        These are independent of column.
+	 */
+	enum RoleIndex {
+		/** sorting */
+		SortRole = Qt::UserRole,
+	};
+
+	int rowCount(const QModelIndex &parent) const;
+	int columnCount(const QModelIndex &parent) const;
+	QVariant data(const QModelIndex &index, int role) const;
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+
+	int update(int unit, std::vector<COutput>& termDepositInfo);
+
+private:
+	std::vector<CacheRecord> tdiCache;
+	QStringList columns;
+
+	ClientModel *clientModel;
+
+	int unit;
+
+	public Q_SLOTS:
+	/* New transaction, or transaction changed status */
+};
+
+#endif // BITCOIN_QT_DEPOSITTABLEMODEL_H

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>596</width>
-    <height>342</height>
+    <width>625</width>
+    <height>465</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -541,7 +541,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableWidget" name="hodlTable">
+    <widget class="QTableView" name="hodlTable">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -555,80 +555,8 @@
       <number>85</number>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
-       <bool>true</bool>
+      <bool>true</bool>
      </attribute>
-     <column>
-      <property name="text">
-       <string>Status</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Principal</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Accrued Interest</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Accrued Value</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>On Maturation</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Term (Days)</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Deposit Block</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Maturation Block</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Estimated Date</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignLeft|AlignVCenter</set>
-      </property>
-     </column>
     </widget>
    </item>
    <item>
@@ -788,11 +716,11 @@
      <height>20</height>
     </rect>
    </property>
-   <property name="styleSheet">
-      <string notr="true">background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000;</string>
-   </property>
    <property name="visible">
     <bool>false</bool>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000;</string>
    </property>
    <property name="wordWrap">
     <bool>true</bool>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -25,313 +25,327 @@
 
 class TxViewDelegate : public QAbstractItemDelegate
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
-    TxViewDelegate(): QAbstractItemDelegate(), unit(BitcoinUnits::HODL)
-    {
+	TxViewDelegate(): QAbstractItemDelegate(), unit(BitcoinUnits::HODL)
+	{
 
-    }
+	}
 
-    inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
-                      const QModelIndex &index ) const
-    {
-        painter->save();
+	inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
+			const QModelIndex &index ) const
+	{
+		painter->save();
 
-        QIcon icon = qvariant_cast<QIcon>(index.data(TransactionTableModel::RawDecorationRole));
-        QRect mainRect = option.rect;
-        QRect decorationRect(mainRect.topLeft(), QSize(DECORATION_SIZE, DECORATION_SIZE));
-        int xspace = DECORATION_SIZE + 8;
-        int ypad = 6;
-        int halfheight = (mainRect.height() - 2*ypad)/2;
-        QRect amountRect(mainRect.left() + xspace, mainRect.top()+ypad, mainRect.width() - xspace, halfheight);
-        QRect addressRect(mainRect.left() + xspace, mainRect.top()+ypad+halfheight, mainRect.width() - xspace, halfheight);
-        icon = SingleColorIcon(icon, SingleColor());
-        icon.paint(painter, decorationRect);
+		QIcon icon = qvariant_cast<QIcon>(index.data(TransactionTableModel::RawDecorationRole));
+		QRect mainRect = option.rect;
+		QRect decorationRect(mainRect.topLeft(), QSize(DECORATION_SIZE, DECORATION_SIZE));
+		int xspace = DECORATION_SIZE + 8;
+		int ypad = 6;
+		int halfheight = (mainRect.height() - 2*ypad)/2;
+		QRect amountRect(mainRect.left() + xspace, mainRect.top()+ypad, mainRect.width() - xspace, halfheight);
+		QRect addressRect(mainRect.left() + xspace, mainRect.top()+ypad+halfheight, mainRect.width() - xspace, halfheight);
+		icon = SingleColorIcon(icon, SingleColor());
+		icon.paint(painter, decorationRect);
 
-        QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
-        QString address = index.data(Qt::DisplayRole).toString();
-        qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
-        bool confirmed = index.data(TransactionTableModel::ConfirmedRole).toBool();
-        QVariant value = index.data(Qt::ForegroundRole);
-        QColor foreground = option.palette.color(QPalette::Text);
-        if(value.canConvert<QBrush>())
-        {
-            QBrush brush = qvariant_cast<QBrush>(value);
-            foreground = brush.color();
-        }
+		QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
+		QString address = index.data(Qt::DisplayRole).toString();
+		qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
+		bool confirmed = index.data(TransactionTableModel::ConfirmedRole).toBool();
+		QVariant value = index.data(Qt::ForegroundRole);
+		QColor foreground = option.palette.color(QPalette::Text);
+		if(value.canConvert<QBrush>())
+		{
+			QBrush brush = qvariant_cast<QBrush>(value);
+			foreground = brush.color();
+		}
 
-        painter->setPen(foreground);
-        QRect boundingRect;
-        painter->drawText(addressRect, Qt::AlignLeft|Qt::AlignVCenter, address, &boundingRect);
+		painter->setPen(foreground);
+		QRect boundingRect;
+		painter->drawText(addressRect, Qt::AlignLeft|Qt::AlignVCenter, address, &boundingRect);
 
-        if (index.data(TransactionTableModel::WatchonlyRole).toBool())
-        {
-            QIcon iconWatchonly = qvariant_cast<QIcon>(index.data(TransactionTableModel::WatchonlyDecorationRole));
-            QRect watchonlyRect(boundingRect.right() + 5, mainRect.top()+ypad+halfheight, 16, halfheight);
-            iconWatchonly.paint(painter, watchonlyRect);
-        }
+		if (index.data(TransactionTableModel::WatchonlyRole).toBool())
+		{
+			QIcon iconWatchonly = qvariant_cast<QIcon>(index.data(TransactionTableModel::WatchonlyDecorationRole));
+			QRect watchonlyRect(boundingRect.right() + 5, mainRect.top()+ypad+halfheight, 16, halfheight);
+			iconWatchonly.paint(painter, watchonlyRect);
+		}
 
-        if(amount < 0)
-        {
-            foreground = COLOR_NEGATIVE;
-        }
-        else if(!confirmed)
-        {
-            foreground = COLOR_UNCONFIRMED;
-        }
-        else
-        {
-            foreground = option.palette.color(QPalette::Text);
-        }
-        painter->setPen(foreground);
-        QString amountText = BitcoinUnits::formatWithUnit(unit, amount, true, BitcoinUnits::separatorAlways);
-        if(!confirmed)
-        {
-            amountText = QString("[") + amountText + QString("]");
-        }
-        painter->drawText(amountRect, Qt::AlignRight|Qt::AlignVCenter, amountText);
+		if(amount < 0)
+		{
+			foreground = COLOR_NEGATIVE;
+		}
+		else if(!confirmed)
+		{
+			foreground = COLOR_UNCONFIRMED;
+		}
+		else
+		{
+			foreground = option.palette.color(QPalette::Text);
+		}
+		painter->setPen(foreground);
+		QString amountText = BitcoinUnits::formatWithUnit(unit, amount, true, BitcoinUnits::separatorAlways);
+		if(!confirmed)
+		{
+			amountText = QString("[") + amountText + QString("]");
+		}
+		painter->drawText(amountRect, Qt::AlignRight|Qt::AlignVCenter, amountText);
 
-        painter->setPen(option.palette.color(QPalette::Text));
-        painter->drawText(amountRect, Qt::AlignLeft|Qt::AlignVCenter, GUIUtil::dateTimeStr(date));
+		painter->setPen(option.palette.color(QPalette::Text));
+		painter->drawText(amountRect, Qt::AlignLeft|Qt::AlignVCenter, GUIUtil::dateTimeStr(date));
 
-        painter->restore();
-    }
+		painter->restore();
+	}
 
-    inline QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
-    {
-        return QSize(DECORATION_SIZE, DECORATION_SIZE);
-    }
+	inline QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+	{
+		return QSize(DECORATION_SIZE, DECORATION_SIZE);
+	}
 
-    int unit;
+	int unit;
 
 };
+
+DepositSortFilterProxyModel::DepositSortFilterProxyModel(QObject *parent)
+: QSortFilterProxyModel(parent) {
+	this->setSortRole( DepositTableModel::SortRole );
+}
+
 #include "overviewpage.moc"
 
 OverviewPage::OverviewPage(QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::OverviewPage),
-    clientModel(0),
-    walletModel(0),
-    currentBalance(-1),
-    currentUnconfirmedBalance(-1),
-    currentImmatureBalance(-1),
-    currentWatchOnlyBalance(-1),
-    currentWatchUnconfBalance(-1),
-    currentWatchImmatureBalance(-1),
-    txdelegate(new TxViewDelegate()),
-    filter(0)
+    		QWidget(parent),
+			ui(new Ui::OverviewPage),
+			clientModel(0),
+			walletModel(0),
+			currentBalance(-1),
+			currentUnconfirmedBalance(-1),
+			currentImmatureBalance(-1),
+			currentWatchOnlyBalance(-1),
+			currentWatchUnconfBalance(-1),
+			currentWatchImmatureBalance(-1),
+			txdelegate(new TxViewDelegate()),
+			filter(0)
 {
-    ui->setupUi(this);
+	ui->setupUi(this);
 
-    // use a SingleColorIcon for the "out of sync warning" icon
-    QIcon icon = SingleColorIcon(":/icons/warning");
-    icon.addPixmap(icon.pixmap(QSize(64,64), QIcon::Normal), QIcon::Disabled); // also set the disabled icon because we are using a disabled QPushButton to work around missing HiDPI support of QLabel (https://bugreports.qt.io/browse/QTBUG-42503)
-    ui->labelTransactionsStatus->setIcon(icon);
-    ui->labelWalletStatus->setIcon(icon);
+	ui->hodlTable->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	ui->hodlTable->setAlternatingRowColors(true);
+	ui->hodlTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+	ui->hodlTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	ui->hodlTable->verticalHeader()->show(); // index column
+	ui->hodlTable->verticalHeader()->setDefaultAlignment(Qt::AlignHCenter|Qt::AlignVCenter);
+	// ui->hodlTable->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-    // Recent transactions
-    ui->listTransactions->setItemDelegate(txdelegate);
-    ui->listTransactions->setIconSize(QSize(DECORATION_SIZE, DECORATION_SIZE));
-    ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
-    ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
+	depositModel = new DepositTableModel(this->clientModel, this);
+	depositProxyModel = new DepositSortFilterProxyModel(this);
+	depositProxyModel->setSourceModel(depositModel);
+	ui->hodlTable->setModel(depositProxyModel);
 
-    connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
+	// Fetch sort flag
+	bool sortflag = GetArg("-sortearnings", true);
+	LogPrintf("sort earnings flag = %b\n", sortflag);
 
-    // start with displaying the "out of sync" warnings
-    showOutOfSyncWarning(true);
+	ui->hodlTable->setSortingEnabled(sortflag);
+
+	// use a SingleColorIcon for the "out of sync warning" icon
+	QIcon icon = SingleColorIcon(":/icons/warning");
+	icon.addPixmap(icon.pixmap(QSize(64,64), QIcon::Normal), QIcon::Disabled); // also set the disabled icon because we are using a disabled QPushButton to work around missing HiDPI support of QLabel (https://bugreports.qt.io/browse/QTBUG-42503)
+	ui->labelTransactionsStatus->setIcon(icon);
+	ui->labelWalletStatus->setIcon(icon);
+
+	// Recent transactions
+	ui->listTransactions->setItemDelegate(txdelegate);
+	ui->listTransactions->setIconSize(QSize(DECORATION_SIZE, DECORATION_SIZE));
+	ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
+	ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
+
+	connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
+
+	// start with displaying the "out of sync" warnings
+	showOutOfSyncWarning(true);
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
 {
-    if(filter)
-        Q_EMIT transactionClicked(filter->mapToSource(index));
+	if(filter)
+		Q_EMIT transactionClicked(filter->mapToSource(index));
 }
 
 OverviewPage::~OverviewPage()
 {
-    delete ui;
+	delete ui;
 }
 
 void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo)
 {
-    int unit = walletModel->getOptionsModel()->getDisplayUnit();
-    currentBalance = balance;
-    currentUnconfirmedBalance = unconfirmedBalance;
-    currentImmatureBalance = immatureBalance;
-    currentWatchOnlyBalance = watchOnlyBalance;
-    currentWatchUnconfBalance = watchUnconfBalance;
-    currentWatchImmatureBalance = watchImmatureBalance;
-    ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance, false, BitcoinUnits::separatorAlways));
-    ui->labelUnconfirmed->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelImmature->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balance + unconfirmedBalance + immatureBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchAvailable->setText(BitcoinUnits::formatWithUnit(unit, watchOnlyBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchPending->setText(BitcoinUnits::formatWithUnit(unit, watchUnconfBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchImmature->setText(BitcoinUnits::formatWithUnit(unit, watchImmatureBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelWatchTotal->setText(BitcoinUnits::formatWithUnit(unit, watchOnlyBalance + watchUnconfBalance + watchImmatureBalance, false, BitcoinUnits::separatorAlways));
+	int unit = walletModel->getOptionsModel()->getDisplayUnit();
+	currentBalance = balance;
+	currentUnconfirmedBalance = unconfirmedBalance;
+	currentImmatureBalance = immatureBalance;
+	currentWatchOnlyBalance = watchOnlyBalance;
+	currentWatchUnconfBalance = watchUnconfBalance;
+	currentWatchImmatureBalance = watchImmatureBalance;
+	ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance, false, BitcoinUnits::separatorAlways));
+	ui->labelUnconfirmed->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelImmature->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, balance + unconfirmedBalance + immatureBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelWatchAvailable->setText(BitcoinUnits::formatWithUnit(unit, watchOnlyBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelWatchPending->setText(BitcoinUnits::formatWithUnit(unit, watchUnconfBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelWatchImmature->setText(BitcoinUnits::formatWithUnit(unit, watchImmatureBalance, false, BitcoinUnits::separatorAlways));
+	ui->labelWatchTotal->setText(BitcoinUnits::formatWithUnit(unit, watchOnlyBalance + watchUnconfBalance + watchImmatureBalance, false, BitcoinUnits::separatorAlways));
 
-    // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
-    // for the non-mining users
-    bool showImmature = immatureBalance != 0;
-    bool showWatchOnlyImmature = watchImmatureBalance != 0;
+	// only show immature (newly mined) balance if it's non-zero, so as not to complicate things
+	// for the non-mining users
+	bool showImmature = immatureBalance != 0;
+	bool showWatchOnlyImmature = watchImmatureBalance != 0;
 
-    // Fetch sort flag
-    bool sort_flag = GetArg("-sorthodlings", true);
-    LogPrintf("sort hodlings flag = %b\n", sort_flag);
+	// for symmetry reasons also show immature label when the watch-only one is shown
+	ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
+	ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
+	ui->labelWatchImmature->setVisible(showWatchOnlyImmature); // show watch-only immature balance
 
-    // for symmetry reasons also show immature label when the watch-only one is shown
-    ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
-    ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
-    ui->labelWatchImmature->setVisible(showWatchOnlyImmature); // show watch-only immature balance
+	bool sortflag = GetArg("-sortearnings", true);
+	bool sortOrder = true;
+	int sortSection = -1;
+	if (sortflag) {
+		// save sort direction and sort order
+		sortOrder = ui->hodlTable->horizontalHeader()->sortIndicatorOrder() == Qt::AscendingOrder;
+		sortSection = ui->hodlTable->horizontalHeader()->sortIndicatorSection();
+	}
 
-    ui->hodlTable->setRowCount(termDepositInfo.size());
+	depositModel->update(unit, termDepositInfo);
 
-    // actually update labels
-    int nDisplayUnit = BitcoinUnits::HODL;
-    // Disable sorting outside the for loop 
-    ui->hodlTable->setSortingEnabled(false);
-    
-    uint64_t totalLocked  = 0;
-    uint64_t totalAccrued = 0;
-    uint64_t totalMatured = 0;
-     
-    for(int i=0;i<termDepositInfo.size();i++){
-        COutput ctermDeposit=termDepositInfo[i];
-        CTxOut termDeposit=ctermDeposit.tx->vout[ctermDeposit.i];
-        int curHeight=this->clientModel->getNumBlocks();
-        int lockHeight=curHeight-ctermDeposit.nDepth;
-        int releaseBlock=termDeposit.scriptPubKey.GetTermDepositReleaseBlock();
-        int term =releaseBlock-lockHeight;
-        int blocksRemaining=releaseBlock-curHeight;
-        CAmount withInterest=termDeposit.GetValueWithInterest(lockHeight,(curHeight<releaseBlock?curHeight:releaseBlock));
-        CAmount matureValue=termDeposit.GetValueWithInterest(lockHeight,releaseBlock);
-        int blocksSoFar=curHeight-lockHeight;
+	if (sortflag && sortSection >= 0) {
+		// restore sort order and direction
+		ui->hodlTable->sortByColumn(sortSection, sortOrder ? Qt::AscendingOrder : Qt::DescendingOrder);
+	}
 
-        double interestRatePerBlock=pow(((0.0+matureValue)/termDeposit.nValue),1.0/term);
-        double interestRate=(pow(interestRatePerBlock,365*561)-1)*100;
-        
-        if(curHeight>=releaseBlock){
-            ui->hodlTable->setItem(i, 0, new QTableWidgetItem(QString("Matured (Warning: this amount is no longer earning interest of any kind)")));
-            totalMatured += matureValue;
-        }else{
-            ui->hodlTable->setItem(i, 0, new QTableWidgetItem(QString("HOdled")));
-            totalAccrued += (withInterest-termDeposit.nValue);
-	    totalLocked  += termDeposit.nValue;
-        }
+	// calculation of sums
+	uint64_t totalLocked  = 0;
+	uint64_t totalAccrued = 0;
+	uint64_t totalMatured = 0;
 
-        ui->hodlTable->setItem(i, 1, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, termDeposit.nValue)));
-        ui->hodlTable->setItem(i, 2, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest-termDeposit.nValue)));
-        ui->hodlTable->setItem(i, 3, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, withInterest)));
-        ui->hodlTable->setItem(i, 4, new QTableWidgetItem(BitcoinUnits::format(nDisplayUnit, matureValue)));
-        ui->hodlTable->setItem(i, 5, new QTableWidgetItem(QString::number((term)/561)));
+	int maturedNowCount = 0;
+	CAmount maturedNowAmount = 0;
 
-        if(!sort_flag){
-            ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight)));
-            ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock)));
-        }else{
-            ui->hodlTable->setItem(i, 6, new QTableWidgetItem(QString::number(lockHeight).rightJustified(7,'0')));
-            ui->hodlTable->setItem(i, 7, new QTableWidgetItem(QString::number(releaseBlock).rightJustified(7,'0')));
-        }
+	for(int i=0;i<termDepositInfo.size();i++){
+		COutput ctermDeposit = termDepositInfo[i];
+		CTxOut termDeposit = ctermDeposit.tx->vout[ctermDeposit.i];
+		int curHeight = this->clientModel->getNumBlocks();
+		int lockHeight = curHeight - ctermDeposit.nDepth;
+		int releaseBlock = termDeposit.scriptPubKey.GetTermDepositReleaseBlock();
+		// int term = releaseBlock - lockHeight;
+		// int blocksRemaining = releaseBlock - curHeight;
+		CAmount withInterest = termDeposit.GetValueWithInterest(lockHeight,(curHeight<releaseBlock?curHeight:releaseBlock));
+		CAmount matureValue = termDeposit.GetValueWithInterest(lockHeight,releaseBlock);
+		// int blocksSoFar = curHeight-lockHeight;
 
-        time_t rawtime;
-        struct tm * timeinfo;
-        char buffer[80];
-        time (&rawtime);
-        rawtime+=blocksRemaining*154;
-        timeinfo = localtime(&rawtime);
-        strftime(buffer,80,"%Y/%m/%d",timeinfo);
-        std::string str(buffer);
+		//double interestRatePerBlock = pow(((0.0+matureValue)/termDeposit.nValue),1.0/term);
+		//double interestRate = (pow(interestRatePerBlock,365*720)-1)*100;
 
-        ui->hodlTable->setItem(i, 8, new QTableWidgetItem(QString(buffer)));
-    }
-   
-    ui->labellocked->setText(BitcoinUnits::formatWithUnit(unit, totalLocked, false, BitcoinUnits::separatorAlways));
-    ui->labelaccrued->setText(BitcoinUnits::formatWithUnit(unit, totalAccrued, false, BitcoinUnits::separatorAlways));
-    ui->labelMatured->setText(BitcoinUnits::formatWithUnit(unit, totalMatured, false, BitcoinUnits::separatorAlways));
- 
-    if(sort_flag){
-     ui->hodlTable->setSortingEnabled(true);
-    }
+		if (curHeight == releaseBlock) {
+			maturedNowCount++;
+			maturedNowAmount += matureValue;
+		}
+
+		if (curHeight >= releaseBlock) {
+			totalMatured += matureValue;
+		} else {
+			totalAccrued += (withInterest - termDeposit.nValue);
+			totalLocked  += termDeposit.nValue;
+		}
+
+	}
+
+	ui->labellocked->setText(BitcoinUnits::formatWithUnit(unit, totalLocked, false, BitcoinUnits::separatorAlways));
+	ui->labelaccrued->setText(BitcoinUnits::formatWithUnit(unit, totalAccrued, false, BitcoinUnits::separatorAlways));
+	ui->labelMatured->setText(BitcoinUnits::formatWithUnit(unit, totalMatured, false, BitcoinUnits::separatorAlways));
+
+	if (maturedNowCount > 0) {
+		Q_EMIT maturedCoinsNotification(maturedNowCount, unit, maturedNowAmount);
+	}
+
 }
 
 // show/hide watch-only labels
 void OverviewPage::updateWatchOnlyLabels(bool showWatchOnly)
 {
-    ui->labelSpendable->setVisible(showWatchOnly);      // show spendable label (only when watch-only is active)
-    ui->labelWatchonly->setVisible(showWatchOnly);      // show watch-only label
-    ui->lineWatchBalance->setVisible(showWatchOnly);    // show watch-only balance separator line
-    ui->labelWatchAvailable->setVisible(showWatchOnly); // show watch-only available balance
-    ui->labelWatchPending->setVisible(showWatchOnly);   // show watch-only pending balance
-    ui->labelWatchTotal->setVisible(showWatchOnly);     // show watch-only total balance
+	ui->labelSpendable->setVisible(showWatchOnly);      // show spendable label (only when watch-only is active)
+	ui->labelWatchonly->setVisible(showWatchOnly);      // show watch-only label
+	ui->lineWatchBalance->setVisible(showWatchOnly);    // show watch-only balance separator line
+	ui->labelWatchAvailable->setVisible(showWatchOnly); // show watch-only available balance
+	ui->labelWatchPending->setVisible(showWatchOnly);   // show watch-only pending balance
+	ui->labelWatchTotal->setVisible(showWatchOnly);     // show watch-only total balance
 
-    if (!showWatchOnly)
-        ui->labelWatchImmature->hide();
+	if (!showWatchOnly)
+		ui->labelWatchImmature->hide();
 }
 
 void OverviewPage::setClientModel(ClientModel *model)
 {
-    this->clientModel = model;
-    if(model)
-    {
-        // Show warning if this is a prerelease version
-        connect(model, SIGNAL(alertsChanged(QString)), this, SLOT(updateAlerts(QString)));
-        updateAlerts(model->getStatusBarWarnings());
-    }
+	this->clientModel = model;
+	if(model)
+	{
+		// Show warning if this is a prerelease version
+		connect(model, SIGNAL(alertsChanged(QString)), this, SLOT(updateAlerts(QString)));
+		updateAlerts(model->getStatusBarWarnings());
+	}
 }
 
 void OverviewPage::setWalletModel(WalletModel *model)
 {
-    this->walletModel = model;
-    if(model && model->getOptionsModel())
-    {
-        // Set up transaction list
-        filter = new TransactionFilterProxy();
-        filter->setSourceModel(model->getTransactionTableModel());
-        filter->setLimit(NUM_ITEMS);
-        filter->setDynamicSortFilter(true);
-        filter->setSortRole(Qt::EditRole);
-        filter->setShowInactive(false);
-        filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
+	this->walletModel = model;
+	if(model && model->getOptionsModel())
+	{
+		// Set up transaction list
+		filter = new TransactionFilterProxy();
+		filter->setSourceModel(model->getTransactionTableModel());
+		filter->setLimit(NUM_ITEMS);
+		filter->setDynamicSortFilter(true);
+		filter->setSortRole(Qt::EditRole);
+		filter->setShowInactive(false);
+		filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
 
-        ui->listTransactions->setModel(filter);
-        ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
+		ui->listTransactions->setModel(filter);
+		ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 
-        // Keep up to date with wallet
-        setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(),model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance(),model->GetTermDepositInfo());
-        connect(model, SIGNAL(balanceChanged(CAmount,CAmount,CAmount,CAmount,CAmount,CAmount,std::vector<COutput>)), this, SLOT(setBalance(CAmount,CAmount,CAmount,CAmount,CAmount,CAmount,std::vector<COutput>)));
+		// Keep up to date with wallet
+		setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(),model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance(),model->GetTermDepositInfo());
+		connect(model, SIGNAL(balanceChanged(CAmount,CAmount,CAmount,CAmount,CAmount,CAmount,std::vector<COutput>)), this, SLOT(setBalance(CAmount,CAmount,CAmount,CAmount,CAmount,CAmount,std::vector<COutput>)));
 
-        connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+		connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
-        updateWatchOnlyLabels(model->haveWatchOnly());
-        connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
-    }
+		updateWatchOnlyLabels(model->haveWatchOnly());
+		connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
+	}
 
-    // update the display unit, to not use the default ("HODL")
-    updateDisplayUnit();
+	// update the display unit, to not use the default ("HODL")
+	updateDisplayUnit();
 }
 
 void OverviewPage::updateDisplayUnit()
 {
-    if(walletModel && walletModel->getOptionsModel())
-    {
-        if(currentBalance != -1)
-            setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance,currentWatchOnlyBalance, currentWatchUnconfBalance, currentWatchImmatureBalance, walletModel->GetTermDepositInfo());
+	if(walletModel && walletModel->getOptionsModel())
+	{
+		if(currentBalance != -1)
+			setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance,currentWatchOnlyBalance, currentWatchUnconfBalance, currentWatchImmatureBalance, walletModel->GetTermDepositInfo());
 
-        // Update txdelegate->unit with the current unit
-        txdelegate->unit = walletModel->getOptionsModel()->getDisplayUnit();
+		// Update txdelegate->unit with the current unit
+		txdelegate->unit = walletModel->getOptionsModel()->getDisplayUnit();
 
-        ui->listTransactions->update();
-    }
+		ui->listTransactions->update();
+	}
 }
 
 void OverviewPage::updateAlerts(const QString &warnings)
 {
-    this->ui->labelAlerts->setVisible(!warnings.isEmpty());
-    this->ui->labelAlerts->setText(warnings);
+	this->ui->labelAlerts->setVisible(!warnings.isEmpty());
+	this->ui->labelAlerts->setText(warnings);
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)
 {
-    ui->labelWalletStatus->setVisible(fShow);
-    ui->labelTransactionsStatus->setVisible(fShow);
+	ui->labelWalletStatus->setVisible(fShow);
+	ui->labelTransactionsStatus->setVisible(fShow);
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -7,12 +7,14 @@
 
 #include "amount.h"
 #include "primitives/transaction.h"
+#include "deposittablemodel.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h" // for COutput
 #endif // ENABLE_WALLET
 
 #include <QWidget>
+#include <QSortFilterProxyModel>
 
 class ClientModel;
 class TransactionFilterProxy;
@@ -20,54 +22,71 @@ class TxViewDelegate;
 class WalletModel;
 
 namespace Ui {
-    class OverviewPage;
+class OverviewPage;
 }
 
 QT_BEGIN_NAMESPACE
 class QModelIndex;
 QT_END_NAMESPACE
 
+class DepositSortFilterProxyModel : public QSortFilterProxyModel
+{
+	Q_OBJECT
+
+public:
+	explicit DepositSortFilterProxyModel(QObject *parent = 0);
+
+protected:
+	// bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
+};
+
 /** Overview ("home") page widget */
 class OverviewPage : public QWidget
 {
-    Q_OBJECT
+	Q_OBJECT
 
 public:
-    explicit OverviewPage(QWidget *parent = 0);
-    ~OverviewPage();
+	explicit OverviewPage(QWidget *parent = 0);
+	~OverviewPage();
 
-    void setClientModel(ClientModel *clientModel);
-    void setWalletModel(WalletModel *walletModel);
-    void showOutOfSyncWarning(bool fShow);
+	void setClientModel(ClientModel *clientModel);
+	void setWalletModel(WalletModel *walletModel);
+	void showOutOfSyncWarning(bool fShow);
 
 public Q_SLOTS:
 #ifdef ENABLE_WALLET
-    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
-                    const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
+	void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
+			const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, std::vector<COutput> termDepositInfo);
 #endif // ENABLE_WALLET
 
 Q_SIGNALS:
-    void transactionClicked(const QModelIndex &index);
+	/** When transaction is clicked */
+	void transactionClicked(const QModelIndex &index);
+	/** Notify that matured coins appeared */
+	void maturedCoinsNotification(int count, int unit, CAmount& amount);
 
 private:
-    Ui::OverviewPage *ui;
-    ClientModel *clientModel;
-    WalletModel *walletModel;
-    CAmount currentBalance;
-    CAmount currentUnconfirmedBalance;
-    CAmount currentImmatureBalance;
-    CAmount currentWatchOnlyBalance;
-    CAmount currentWatchUnconfBalance;
-    CAmount currentWatchImmatureBalance;
+	Ui::OverviewPage *ui;
+	ClientModel *clientModel;
+	WalletModel *walletModel;
+	CAmount currentBalance;
+	CAmount currentUnconfirmedBalance;
+	CAmount currentImmatureBalance;
+	CAmount currentWatchOnlyBalance;
+	CAmount currentWatchUnconfBalance;
+	CAmount currentWatchImmatureBalance;
 
-    TxViewDelegate *txdelegate;
-    TransactionFilterProxy *filter;
+	TxViewDelegate *txdelegate;
+	TransactionFilterProxy *filter;
+
+	DepositSortFilterProxyModel *depositProxyModel;
+	DepositTableModel *depositModel;
 
 private Q_SLOTS:
-    void updateDisplayUnit();
-    void handleTransactionClicked(const QModelIndex &index);
-    void updateAlerts(const QString &warnings);
-    void updateWatchOnlyLabels(bool showWatchOnly);
+	void updateDisplayUnit();
+	void handleTransactionClicked(const QModelIndex &index);
+	void updateAlerts(const QString &warnings);
+	void updateWatchOnlyLabels(bool showWatchOnly);
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -92,6 +92,8 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         // Clicking on a transaction on the overview page simply sends you to transaction history page
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoHistoryPage()));
 
+        connect(overviewPage, SIGNAL(maturedCoinsNotification(int, int, CAmount&)), gui, SLOT(maturedCoinsNotification(int, int, CAmount&)));
+
         // Receive and report messages
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
 


### PR DESCRIPTION
Please make sure you checked the box ('x') before creating the pull request.

- [x] I have tested my changes.
- [x] I have made sure my branch is rebased. it has no merge commits nor stray commits from other people.

----

### Description (what did you change?)

Replaces the term deposit table from QTableWidget with QTableView with support of DepositTableModel. It brings the performance boost because of dynamic nature of QTableView renderer and supports correct sorting in all columns.

Also added the notification message on maturation of deposits. It is important because the coins should be moved to start earning interest again.

Also changes historical entries in .gitignore to more modern ones.

----

### Related github issues (if there are any) 

No issues so far, just new features.

----

### Notes

The code was ported from ROICoin forthcoming 1.1.4 release as suggested by one of contributors. It was tested there and found correct and fast. The bounty for this rework will be nice, address is HTheTDDN2ZkjmiUmJZq8WnYxfd125F6kcT
