### PR TITLE
Fix for two bugs that prevents users from transfering larger amounts

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -18,7 +18,7 @@ static const CAmount CENT = 1000000;
 
 /** No amount larger than this (in satoshi) is valid */
 static const CAmount MAX_MONEY = 600000000 * COIN;
-inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0); }
 
 /** Type-safe wrapper class to for fee rates
  * (how much to pay based on transaction size)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -126,7 +126,7 @@ static inline int64_t roundint64(double d)
 CAmount AmountFromValue(const Value& value)
 {
     double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > 21000000.0)
+    if (dAmount <= 0.0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     CAmount nAmount = roundint64(dAmount * COIN);
     if (!MoneyRange(nAmount))


### PR DESCRIPTION
Please make sure you checked the box ('x') before creating the pull request.

- [x] I have tested my changes.
- [x] I have made sure my branch is rebased. it has no merge commits nor stray commits from other people.
- [-] I have taken the base code from the dev branch, v0.11.3

(taken from master branch)

----

### Description (what did you change?)
Fixed bug in RPC that limits amounts to 21M
Remove invalid money range check that limits outputs to MAX_MONEY

----

### Related github issues (if there are any) 

----

### Notes
No consensus changes, no hard-fork required
